### PR TITLE
Fix package references across go-sdk

### DIFF
--- a/go-sdk/CONTRIBUTING.md
+++ b/go-sdk/CONTRIBUTING.md
@@ -174,8 +174,8 @@ import (
     "github.com/gorilla/websocket"
 
     // Local imports
-    "github.com/ag-ui/go-sdk/pkg/core"
-    "github.com/ag-ui/go-sdk/internal/protocol"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/core"
+    "github.com/mattsp1290/ag-ui/go-sdk/internal/protocol"
 )
 ```
 

--- a/go-sdk/DEVELOPMENT.md
+++ b/go-sdk/DEVELOPMENT.md
@@ -6,7 +6,7 @@ Welcome to the AG-UI Go SDK development environment! This guide serves as your c
 
 ```bash
 # Clone and setup
-git clone https://github.com/ag-ui/go-sdk.git
+git clone https://github.com/mattsp1290/ag-ui/go-sdk.git
 cd go-sdk
 
 # Install all development tools
@@ -251,7 +251,7 @@ golangci-lint linters
 
 ### Getting Help
 1. Check this guide and linked documentation
-2. Search existing [GitHub Issues](https://github.com/ag-ui/go-sdk/issues)
+2. Search existing [GitHub Issues](https://github.com/mattsp1290/ag-ui/go-sdk/issues)
 3. Create a new issue with:
    - Go version (`go version`)
    - Operating system

--- a/go-sdk/README.md
+++ b/go-sdk/README.md
@@ -26,7 +26,7 @@ AG-UI is a lightweight, event-based protocol that standardizes how AI agents con
 
 ```bash
 # Install the SDK
-go get github.com/ag-ui/go-sdk
+go get github.com/mattsp1290/ag-ui/go-sdk
 
 # Install development tools (for contributors)
 make tools-install
@@ -44,7 +44,7 @@ make tools-install
 
 ```bash
 # Clone the repository
-git clone https://github.com/ag-ui/go-sdk.git
+git clone https://github.com/mattsp1290/ag-ui/go-sdk.git
 cd go-sdk
 
 # Install all dependencies and development tools
@@ -69,8 +69,8 @@ import (
     "context"
     "log"
 
-    "github.com/ag-ui/go-sdk/pkg/core"
-    "github.com/ag-ui/go-sdk/pkg/server"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/core"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/server"
 )
 
 type EchoAgent struct{}
@@ -109,7 +109,7 @@ import (
     "context"
     "log"
 
-    "github.com/ag-ui/go-sdk/pkg/client"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/client"
 )
 
 func main() {

--- a/go-sdk/docs/API_MIGRATION_REFERENCE.md
+++ b/go-sdk/docs/API_MIGRATION_REFERENCE.md
@@ -230,7 +230,7 @@ logger.Info("Processing request",
 
 #### After
 ```go
-import "github.com/ag-ui/go-sdk/pkg/transport"
+import "github.com/mattsp1290/ag-ui/go-sdk/pkg/transport"
 
 logger := transport.NewLogger()
 

--- a/go-sdk/docs/README.md
+++ b/go-sdk/docs/README.md
@@ -95,8 +95,8 @@ A comprehensive event system that ensures compile-time type safety and automatic
 ```go
 import (
     "context"
-    "github.com/ag-ui/go-sdk/pkg/transport"
-    "github.com/ag-ui/go-sdk/pkg/core/events"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/transport"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // Create and configure transport
@@ -122,7 +122,7 @@ transport.Send(ctx, event)
 ### Type-Safe Event Creation
 
 ```go
-import "github.com/ag-ui/go-sdk/pkg/core/events"
+import "github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 
 // Using constructors
 event := events.NewTextMessageContentEvent("msg-123", "Hello, world!")

--- a/go-sdk/docs/event_system_api.md
+++ b/go-sdk/docs/event_system_api.md
@@ -415,7 +415,7 @@ import (
     "fmt"
     "log"
     
-    "github.com/ag-ui/go-sdk/pkg/core/events"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 func main() {
@@ -455,7 +455,7 @@ import (
     "log"
     "time"
     
-    "github.com/ag-ui/go-sdk/pkg/core/events"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 func main() {
@@ -498,7 +498,7 @@ import (
     "fmt"
     "log"
     
-    "github.com/ag-ui/go-sdk/pkg/core/events"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 func main() {
@@ -536,7 +536,7 @@ import (
     "fmt"
     "log"
     
-    "github.com/ag-ui/go-sdk/pkg/core/events"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 func main() {
@@ -604,7 +604,7 @@ import (
     "fmt"
     "log"
     
-    "github.com/ag-ui/go-sdk/pkg/core/events"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 func main() {
@@ -660,7 +660,7 @@ import (
     "log"
     "time"
     
-    "github.com/ag-ui/go-sdk/pkg/core/events"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 func main() {

--- a/go-sdk/docs/migration_guide.md
+++ b/go-sdk/docs/migration_guide.md
@@ -58,8 +58,8 @@ transport.Send(event)
 
 ```go
 import (
-    "github.com/ag-ui/go-sdk/pkg/transport"
-    "github.com/ag-ui/go-sdk/pkg/core/events"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/transport"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // New type-safe configuration

--- a/go-sdk/docs/transport_abstraction_api.md
+++ b/go-sdk/docs/transport_abstraction_api.md
@@ -186,8 +186,8 @@ import (
     "log"
     "time"
     
-    "github.com/ag-ui/go-sdk/pkg/transport"
-    "github.com/ag-ui/go-sdk/pkg/core/events"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/transport"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 func main() {
@@ -245,7 +245,7 @@ import (
     "fmt"
     "log"
     
-    "github.com/ag-ui/go-sdk/pkg/transport"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/transport"
 )
 
 func main() {
@@ -299,8 +299,8 @@ import (
     "log"
     "time"
     
-    "github.com/ag-ui/go-sdk/pkg/transport"
-    "github.com/ag-ui/go-sdk/pkg/core/events"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/transport"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 func main() {
@@ -401,7 +401,7 @@ import (
     "log"
     "time"
     
-    "github.com/ag-ui/go-sdk/pkg/transport"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/transport"
 )
 
 func main() {

--- a/go-sdk/examples/events/go.mod
+++ b/go-sdk/examples/events/go.mod
@@ -1,8 +1,8 @@
-module github.com/ag-ui/go-sdk/examples/events
+module github.com/mattsp1290/ag-ui/go-sdk/examples/events
 
 go 1.24.4
 
-require github.com/ag-ui/go-sdk v0.1.0
+require github.com/mattsp1290/ag-ui/go-sdk v0.1.0
 
 require (
 	github.com/go-logr/logr v1.4.2 // indirect
@@ -16,4 +16,4 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 )
 
-replace github.com/ag-ui/go-sdk => ../..
+replace github.com/mattsp1290/ag-ui/go-sdk => ../..

--- a/go-sdk/examples/events/type_safe_usage/go.mod
+++ b/go-sdk/examples/events/type_safe_usage/go.mod
@@ -1,12 +1,12 @@
-module github.com/ag-ui/go-sdk/examples/events/type_safe_usage
+module github.com/mattsp1290/ag-ui/go-sdk/examples/events/type_safe_usage
 
 go 1.23.0
 
 toolchain go1.24.4
 
-replace github.com/ag-ui/go-sdk => ../../..
+replace github.com/mattsp1290/ag-ui/go-sdk => ../../..
 
-require github.com/ag-ui/go-sdk v0.0.0-00010101000000-000000000000
+require github.com/mattsp1290/ag-ui/go-sdk v0.0.0-00010101000000-000000000000
 
 require (
 	github.com/go-logr/logr v1.4.2 // indirect

--- a/go-sdk/examples/events/type_safe_usage/main.go
+++ b/go-sdk/examples/events/type_safe_usage/main.go
@@ -13,7 +13,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 func main() {

--- a/go-sdk/examples/messages/go.mod
+++ b/go-sdk/examples/messages/go.mod
@@ -1,8 +1,8 @@
-module github.com/ag-ui/go-sdk/examples/messages
+module github.com/mattsp1290/ag-ui/go-sdk/examples/messages
 
 go 1.24.4
 
-require github.com/ag-ui/go-sdk v0.1.0
+require github.com/mattsp1290/ag-ui/go-sdk v0.1.0
 
 require (
 	github.com/go-logr/logr v1.4.2 // indirect
@@ -16,4 +16,4 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 )
 
-replace github.com/ag-ui/go-sdk => ../..
+replace github.com/mattsp1290/ag-ui/go-sdk => ../..

--- a/go-sdk/examples/state/basic_state_sync/go.mod
+++ b/go-sdk/examples/state/basic_state_sync/go.mod
@@ -1,8 +1,8 @@
-module github.com/ag-ui/go-sdk/examples/state/basic_state_sync
+module github.com/mattsp1290/ag-ui/go-sdk/examples/state/basic_state_sync
 
 go 1.24.4
 
-require github.com/ag-ui/go-sdk v0.0.0
+require github.com/mattsp1290/ag-ui/go-sdk v0.0.0
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -29,4 +29,4 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 )
 
-replace github.com/ag-ui/go-sdk => ../../../
+replace github.com/mattsp1290/ag-ui/go-sdk => ../../../

--- a/go-sdk/examples/state/collaborative_editing/go.mod
+++ b/go-sdk/examples/state/collaborative_editing/go.mod
@@ -1,8 +1,8 @@
-module github.com/ag-ui/go-sdk/examples/state/collaborative_editing
+module github.com/mattsp1290/ag-ui/go-sdk/examples/state/collaborative_editing
 
 go 1.24.4
 
-require github.com/ag-ui/go-sdk v0.0.0
+require github.com/mattsp1290/ag-ui/go-sdk v0.0.0
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -29,4 +29,4 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 )
 
-replace github.com/ag-ui/go-sdk => ../../../
+replace github.com/mattsp1290/ag-ui/go-sdk => ../../../

--- a/go-sdk/examples/state/collaborative_editing/main.go
+++ b/go-sdk/examples/state/collaborative_editing/main.go
@@ -21,9 +21,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/state"
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/state"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 // Document represents a collaborative document

--- a/go-sdk/examples/state/realtime_dashboard/go.mod
+++ b/go-sdk/examples/state/realtime_dashboard/go.mod
@@ -1,8 +1,8 @@
-module github.com/ag-ui/go-sdk/examples/state/realtime_dashboard
+module github.com/mattsp1290/ag-ui/go-sdk/examples/state/realtime_dashboard
 
 go 1.24.4
 
-require github.com/ag-ui/go-sdk v0.0.0
+require github.com/mattsp1290/ag-ui/go-sdk v0.0.0
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -27,4 +27,4 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 )
 
-replace github.com/ag-ui/go-sdk => ../../../
+replace github.com/mattsp1290/ag-ui/go-sdk => ../../../

--- a/go-sdk/examples/state/realtime_dashboard/main_test.go
+++ b/go-sdk/examples/state/realtime_dashboard/main_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/state"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/state"
 )
 
 // TestGracefulShutdown tests that all resources are properly cleaned up

--- a/go-sdk/examples/tools/basic/cmd/calculator/main.go
+++ b/go-sdk/examples/tools/basic/cmd/calculator/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 // CalculatorExecutor implements basic arithmetic operations.

--- a/go-sdk/examples/tools/basic/cmd/file_operations/main.go
+++ b/go-sdk/examples/tools/basic/cmd/file_operations/main.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 // FileOperationsExecutor implements safe file operations.

--- a/go-sdk/examples/tools/basic/cmd/greeting/main.go
+++ b/go-sdk/examples/tools/basic/cmd/greeting/main.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 // GreetingExecutor implements personalized greeting generation.

--- a/go-sdk/examples/tools/calculator/tests/calculator_test.go
+++ b/go-sdk/examples/tools/calculator/tests/calculator_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 // Import the calculator tool (assuming it's in the main package for now)

--- a/go-sdk/examples/tools/external/cmd/rest_client/main.go
+++ b/go-sdk/examples/tools/external/cmd/rest_client/main.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 // RESTClientExecutor implements a comprehensive REST API client.

--- a/go-sdk/examples/tools/external/cmd/weather_api/main.go
+++ b/go-sdk/examples/tools/external/cmd/weather_api/main.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 // WeatherAPIExecutor implements weather data retrieval from external APIs.

--- a/go-sdk/examples/tools/external/rest-client/go.mod
+++ b/go-sdk/examples/tools/external/rest-client/go.mod
@@ -1,12 +1,12 @@
-module github.com/ag-ui/go-sdk/examples/tools/external/rest-client
+module github.com/mattsp1290/ag-ui/go-sdk/examples/tools/external/rest-client
 
 go 1.24.4
 
-require github.com/ag-ui/go-sdk v0.1.0
+require github.com/mattsp1290/ag-ui/go-sdk v0.1.0
 
 require (
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 )
 
-replace github.com/ag-ui/go-sdk => ../../../..
+replace github.com/mattsp1290/ag-ui/go-sdk => ../../../..

--- a/go-sdk/examples/tools/external/rest-client/rest_client_main.go
+++ b/go-sdk/examples/tools/external/rest-client/rest_client_main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 func main() {

--- a/go-sdk/examples/tools/external/weather-api/go.mod
+++ b/go-sdk/examples/tools/external/weather-api/go.mod
@@ -1,12 +1,12 @@
-module github.com/ag-ui/go-sdk/examples/tools/external/weather-api
+module github.com/mattsp1290/ag-ui/go-sdk/examples/tools/external/weather-api
 
 go 1.24.4
 
-require github.com/ag-ui/go-sdk v0.1.0
+require github.com/mattsp1290/ag-ui/go-sdk v0.1.0
 
 require (
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 )
 
-replace github.com/ag-ui/go-sdk => ../../../..
+replace github.com/mattsp1290/ag-ui/go-sdk => ../../../..

--- a/go-sdk/examples/tools/external/weather-api/weather_api_main.go
+++ b/go-sdk/examples/tools/external/weather-api/weather_api_main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 func main() {

--- a/go-sdk/examples/tools/file-operations/tests/file_operations_test.go
+++ b/go-sdk/examples/tools/file-operations/tests/file_operations_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 // MockFileOperationsExecutor provides a testable version of the file operations tool

--- a/go-sdk/examples/tools/greeting/tests/greeting_test.go
+++ b/go-sdk/examples/tools/greeting/tests/greeting_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 // MockGreetingExecutor provides a testable version of the greeting tool

--- a/go-sdk/examples/tools/performance/async-executor/go.mod
+++ b/go-sdk/examples/tools/performance/async-executor/go.mod
@@ -1,12 +1,12 @@
-module github.com/ag-ui/go-sdk/examples/tools/performance/async-executor
+module github.com/mattsp1290/ag-ui/go-sdk/examples/tools/performance/async-executor
 
 go 1.24.4
 
-require github.com/ag-ui/go-sdk v0.1.0
+require github.com/mattsp1290/ag-ui/go-sdk v0.1.0
 
 require (
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 )
 
-replace github.com/ag-ui/go-sdk => ../../../..
+replace github.com/mattsp1290/ag-ui/go-sdk => ../../../..

--- a/go-sdk/examples/tools/performance/batch-processor/go.mod
+++ b/go-sdk/examples/tools/performance/batch-processor/go.mod
@@ -1,12 +1,12 @@
-module github.com/ag-ui/go-sdk/examples/tools/performance/batch-processor
+module github.com/mattsp1290/ag-ui/go-sdk/examples/tools/performance/batch-processor
 
 go 1.24.4
 
-require github.com/ag-ui/go-sdk v0.1.0
+require github.com/mattsp1290/ag-ui/go-sdk v0.1.0
 
 require (
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 )
 
-replace github.com/ag-ui/go-sdk => ../../../..
+replace github.com/mattsp1290/ag-ui/go-sdk => ../../../..

--- a/go-sdk/examples/tools/performance/cache-demo/go.mod
+++ b/go-sdk/examples/tools/performance/cache-demo/go.mod
@@ -1,12 +1,12 @@
-module github.com/ag-ui/go-sdk/examples/tools/performance/cache-demo
+module github.com/mattsp1290/ag-ui/go-sdk/examples/tools/performance/cache-demo
 
 go 1.24.4
 
-require github.com/ag-ui/go-sdk v0.1.0
+require github.com/mattsp1290/ag-ui/go-sdk v0.1.0
 
 require (
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 )
 
-replace github.com/ag-ui/go-sdk => ../../../..
+replace github.com/mattsp1290/ag-ui/go-sdk => ../../../..

--- a/go-sdk/examples/tools/performance/cmd/async_executor/main.go
+++ b/go-sdk/examples/tools/performance/cmd/async_executor/main.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 // AsyncExecutorTool demonstrates asynchronous execution patterns and performance optimization.

--- a/go-sdk/examples/tools/performance/cmd/batch_processor/main.go
+++ b/go-sdk/examples/tools/performance/cmd/batch_processor/main.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 // BatchProcessorTool demonstrates batch processing optimization techniques.

--- a/go-sdk/examples/tools/performance/cmd/cache_demo/main.go
+++ b/go-sdk/examples/tools/performance/cmd/cache_demo/main.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 // CacheDemoExecutor demonstrates various caching strategies and performance optimizations.

--- a/go-sdk/examples/tools/performance/cmd/resource_monitor/main.go
+++ b/go-sdk/examples/tools/performance/cmd/resource_monitor/main.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 // ResourceMonitorTool demonstrates advanced resource monitoring and optimization techniques.

--- a/go-sdk/examples/tools/performance/resource-monitor/go.mod
+++ b/go-sdk/examples/tools/performance/resource-monitor/go.mod
@@ -1,12 +1,12 @@
-module github.com/ag-ui/go-sdk/examples/tools/performance/resource-monitor
+module github.com/mattsp1290/ag-ui/go-sdk/examples/tools/performance/resource-monitor
 
 go 1.24.4
 
-require github.com/ag-ui/go-sdk v0.1.0
+require github.com/mattsp1290/ag-ui/go-sdk v0.1.0
 
 require (
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 )
 
-replace github.com/ag-ui/go-sdk => ../../../..
+replace github.com/mattsp1290/ag-ui/go-sdk => ../../../..

--- a/go-sdk/examples/tools/streaming/cmd/data_processor/main.go
+++ b/go-sdk/examples/tools/streaming/cmd/data_processor/main.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 // DataProcessorExecutor implements real-time data processing with streaming output.

--- a/go-sdk/examples/tools/streaming/cmd/log_streaming/main.go
+++ b/go-sdk/examples/tools/streaming/cmd/log_streaming/main.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 // LogStreamingExecutor implements real-time log file streaming.

--- a/go-sdk/examples/tools/streaming/data-processor/data_processor_main.go
+++ b/go-sdk/examples/tools/streaming/data-processor/data_processor_main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 func main() {

--- a/go-sdk/examples/tools/streaming/data-processor/go.mod
+++ b/go-sdk/examples/tools/streaming/data-processor/go.mod
@@ -1,12 +1,12 @@
-module github.com/ag-ui/go-sdk/examples/tools/streaming/data-processor
+module github.com/mattsp1290/ag-ui/go-sdk/examples/tools/streaming/data-processor
 
 go 1.24.4
 
-require github.com/ag-ui/go-sdk v0.1.0
+require github.com/mattsp1290/ag-ui/go-sdk v0.1.0
 
 require (
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 )
 
-replace github.com/ag-ui/go-sdk => ../../../..
+replace github.com/mattsp1290/ag-ui/go-sdk => ../../../..

--- a/go-sdk/examples/tools/streaming/log-streaming/go.mod
+++ b/go-sdk/examples/tools/streaming/log-streaming/go.mod
@@ -1,12 +1,12 @@
-module github.com/ag-ui/go-sdk/examples/tools/streaming/log-streaming
+module github.com/mattsp1290/ag-ui/go-sdk/examples/tools/streaming/log-streaming
 
 go 1.24.4
 
-require github.com/ag-ui/go-sdk v0.1.0
+require github.com/mattsp1290/ag-ui/go-sdk v0.1.0
 
 require (
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 )
 
-replace github.com/ag-ui/go-sdk => ../../../..
+replace github.com/mattsp1290/ag-ui/go-sdk => ../../../..

--- a/go-sdk/examples/tools/streaming/log-streaming/log_streaming_main.go
+++ b/go-sdk/examples/tools/streaming/log-streaming/log_streaming_main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 func main() {

--- a/go-sdk/examples/tools/streaming/test/data_processor_test.go
+++ b/go-sdk/examples/tools/streaming/test/data_processor_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 // MockStreamingDataProcessor provides a testable version of the streaming data processor

--- a/go-sdk/examples/tools/validation/api-validator/go.mod
+++ b/go-sdk/examples/tools/validation/api-validator/go.mod
@@ -1,12 +1,12 @@
-module github.com/ag-ui/go-sdk/examples/tools/validation/api-validator
+module github.com/mattsp1290/ag-ui/go-sdk/examples/tools/validation/api-validator
 
 go 1.24.4
 
-require github.com/ag-ui/go-sdk v0.1.0
+require github.com/mattsp1290/ag-ui/go-sdk v0.1.0
 
 require (
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 )
 
-replace github.com/ag-ui/go-sdk => ../../../..
+replace github.com/mattsp1290/ag-ui/go-sdk => ../../../..

--- a/go-sdk/examples/tools/validation/cmd/api_validator/main.go
+++ b/go-sdk/examples/tools/validation/cmd/api_validator/main.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 // APIValidatorExecutor implements comprehensive API request/response validation.

--- a/go-sdk/examples/tools/validation/cmd/data_transformer/main.go
+++ b/go-sdk/examples/tools/validation/cmd/data_transformer/main.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 // DataTransformerExecutor implements comprehensive data transformation with validation.

--- a/go-sdk/examples/tools/validation/data-transformer/go.mod
+++ b/go-sdk/examples/tools/validation/data-transformer/go.mod
@@ -1,12 +1,12 @@
-module github.com/ag-ui/go-sdk/examples/tools/validation/data-transformer
+module github.com/mattsp1290/ag-ui/go-sdk/examples/tools/validation/data-transformer
 
 go 1.24.4
 
-require github.com/ag-ui/go-sdk v0.1.0
+require github.com/mattsp1290/ag-ui/go-sdk v0.1.0
 
 require (
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 )
 
-replace github.com/ag-ui/go-sdk => ../../../..
+replace github.com/mattsp1290/ag-ui/go-sdk => ../../../..

--- a/go-sdk/examples/transport/basic_usage/go.mod
+++ b/go-sdk/examples/transport/basic_usage/go.mod
@@ -1,12 +1,12 @@
-module github.com/ag-ui/go-sdk/examples/transport/basic_usage
+module github.com/mattsp1290/ag-ui/go-sdk/examples/transport/basic_usage
 
 go 1.23.0
 
 toolchain go1.24.4
 
-replace github.com/ag-ui/go-sdk => ../../..
+replace github.com/mattsp1290/ag-ui/go-sdk => ../../..
 
-require github.com/ag-ui/go-sdk v0.0.0-00010101000000-000000000000
+require github.com/mattsp1290/ag-ui/go-sdk v0.0.0-00010101000000-000000000000
 
 require (
 	github.com/go-logr/logr v1.4.2 // indirect

--- a/go-sdk/examples/transport/basic_usage/main.go
+++ b/go-sdk/examples/transport/basic_usage/main.go
@@ -16,8 +16,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/transport"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/transport"
 )
 
 // MockTransport implements the Transport interface for demonstration

--- a/go-sdk/examples/transport_demo/advanced_events/main.go
+++ b/go-sdk/examples/transport_demo/advanced_events/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/transport"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/transport"
 )
 
 func main() {

--- a/go-sdk/examples/transport_demo/config_errors/main.go
+++ b/go-sdk/examples/transport_demo/config_errors/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/ag-ui/go-sdk/pkg/transport"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/transport"
 )
 
 func main() {

--- a/go-sdk/lint/cmd/main.go
+++ b/go-sdk/lint/cmd/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/ag-ui/go-sdk/lint"
+	"github.com/mattsp1290/ag-ui/go-sdk/lint"
 	"golang.org/x/tools/go/analysis/singlechecker"
 )
 

--- a/go-sdk/pkg/DEPENDENCY_ANALYSIS.md
+++ b/go-sdk/pkg/DEPENDENCY_ANALYSIS.md
@@ -7,24 +7,24 @@ Package Dependency Analysis
 Core Package Dependencies:
 --------------------------
 
-github.com/ag-ui/go-sdk/pkg/core/events imports:
-  - github.com/ag-ui/go-sdk/pkg/proto/generated
-  - github.com/ag-ui/go-sdk/pkg/core
+github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events imports:
+  - github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated
+  - github.com/mattsp1290/ag-ui/go-sdk/pkg/core
 
-github.com/ag-ui/go-sdk/pkg/transport imports:
-  - github.com/ag-ui/go-sdk/pkg/core/events
-  - github.com/ag-ui/go-sdk/pkg/common
+github.com/mattsp1290/ag-ui/go-sdk/pkg/transport imports:
+  - github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events
+  - github.com/mattsp1290/ag-ui/go-sdk/pkg/common
 
-github.com/ag-ui/go-sdk/pkg/state imports:
-  - github.com/ag-ui/go-sdk/pkg/common
-  - github.com/ag-ui/go-sdk/pkg/core/events
-  - github.com/ag-ui/go-sdk/pkg/testing
+github.com/mattsp1290/ag-ui/go-sdk/pkg/state imports:
+  - github.com/mattsp1290/ag-ui/go-sdk/pkg/common
+  - github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events
+  - github.com/mattsp1290/ag-ui/go-sdk/pkg/testing
 
-github.com/ag-ui/go-sdk/pkg/messages imports:
-  - github.com/ag-ui/go-sdk/pkg/core/events
+github.com/mattsp1290/ag-ui/go-sdk/pkg/messages imports:
+  - github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events
 
-github.com/ag-ui/go-sdk/pkg/tools imports:
-  - github.com/ag-ui/go-sdk/pkg/common
+github.com/mattsp1290/ag-ui/go-sdk/pkg/tools imports:
+  - github.com/mattsp1290/ag-ui/go-sdk/pkg/common
 
 
 Circular Dependencies:
@@ -36,9 +36,9 @@ Cross-Package Dependencies:
 ---------------------------
 
 Transport -> Events:
-  - github.com/ag-ui/go-sdk/pkg/core/events
+  - github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events
 
 State -> Events:
-  - github.com/ag-ui/go-sdk/pkg/core/events
+  - github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events
 
 ```

--- a/go-sdk/pkg/client/client.go
+++ b/go-sdk/pkg/client/client.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/ag-ui/go-sdk/pkg/core"
-	agerrors "github.com/ag-ui/go-sdk/pkg/errors"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core"
+	agerrors "github.com/mattsp1290/ag-ui/go-sdk/pkg/errors"
 )
 
 // Client represents a connection to an AG-UI server.

--- a/go-sdk/pkg/client/client_test.go
+++ b/go-sdk/pkg/client/client_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/client"
-	"github.com/ag-ui/go-sdk/pkg/core"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/client"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core"
 )
 
 func TestNew(t *testing.T) {

--- a/go-sdk/pkg/client/doc.go
+++ b/go-sdk/pkg/client/doc.go
@@ -9,7 +9,7 @@
 //
 // Example usage:
 //
-//	import "github.com/ag-ui/go-sdk/pkg/client"
+//	import "github.com/mattsp1290/ag-ui/go-sdk/pkg/client"
 //
 //	// Create a new client
 //	c, err := client.New("http://localhost:8080/ag-ui")

--- a/go-sdk/pkg/common/url_validator.go
+++ b/go-sdk/pkg/common/url_validator.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"strings"
 
-	agerrors "github.com/ag-ui/go-sdk/pkg/errors"
+	agerrors "github.com/mattsp1290/ag-ui/go-sdk/pkg/errors"
 )
 
 // URLValidationOptions defines options for URL validation

--- a/go-sdk/pkg/core/doc.go
+++ b/go-sdk/pkg/core/doc.go
@@ -20,7 +20,7 @@
 //		"log"
 //		"time"
 //
-//		"github.com/ag-ui/go-sdk/pkg/core"
+//		"github.com/mattsp1290/ag-ui/go-sdk/pkg/core"
 //	)
 //
 //	// MyAgent implements the core.Agent interface

--- a/go-sdk/pkg/core/events/README.md
+++ b/go-sdk/pkg/core/events/README.md
@@ -62,7 +62,7 @@ The AG-UI Event Validation System provides comprehensive validation capabilities
 ### Basic Configuration
 
 ```go
-import "github.com/ag-ui/go-sdk/pkg/core/events"
+import "github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 
 // Create validator with default configuration
 validator := events.NewEventValidator()

--- a/go-sdk/pkg/core/events/custom_events.go
+++ b/go-sdk/pkg/core/events/custom_events.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 

--- a/go-sdk/pkg/core/events/doc.go
+++ b/go-sdk/pkg/core/events/doc.go
@@ -37,7 +37,7 @@
 //
 // # Basic Usage
 //
-//	import "github.com/ag-ui/go-sdk/pkg/core/events"
+//	import "github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 //
 //	// Create type-safe events
 //	runEvent := events.NewRunStartedEvent("thread-123", "run-456")

--- a/go-sdk/pkg/core/events/events.go
+++ b/go-sdk/pkg/core/events/events.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
 )
 
 // EventType represents the type of AG-UI event

--- a/go-sdk/pkg/core/events/message_events.go
+++ b/go-sdk/pkg/core/events/message_events.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
 )
 
 // TextMessageStartEvent indicates the start of a streaming text message

--- a/go-sdk/pkg/core/events/run_events.go
+++ b/go-sdk/pkg/core/events/run_events.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
 )
 
 // RunStartedEvent indicates that an agent run has started

--- a/go-sdk/pkg/core/events/serialization.go
+++ b/go-sdk/pkg/core/events/serialization.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/go-sdk/pkg/core/events/state_events.go
+++ b/go-sdk/pkg/core/events/state_events.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 

--- a/go-sdk/pkg/core/events/tool_events.go
+++ b/go-sdk/pkg/core/events/tool_events.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
 )
 
 // ToolCallStartEvent indicates the start of a tool call

--- a/go-sdk/pkg/core/events/typed_events.go
+++ b/go-sdk/pkg/core/events/typed_events.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core"
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
 )
 
 // TypedEvent interface for core events with type safety

--- a/go-sdk/pkg/dependency_analysis.go
+++ b/go-sdk/pkg/dependency_analysis.go
@@ -72,7 +72,7 @@ func AnalyzePackageDependencies(rootPath string) (*DependencyGraph, error) {
 				importPath := strings.Trim(imp.Path.Value, `"`)
 				
 				// Only track internal imports
-				if strings.HasPrefix(importPath, "github.com/ag-ui/go-sdk/") {
+				if strings.HasPrefix(importPath, "github.com/mattsp1290/ag-ui/go-sdk/") {
 					// Skip self-imports in test files (which is normal for _test packages)
 					if strings.HasSuffix(path, "_test.go") && importPath == pkgPath {
 						continue
@@ -157,12 +157,12 @@ func (g *DependencyGraph) PrintDependencyReport() string {
 	
 	// Find core packages
 	corePackages := []string{
-		"github.com/ag-ui/go-sdk/pkg/core",
-		"github.com/ag-ui/go-sdk/pkg/core/events",
-		"github.com/ag-ui/go-sdk/pkg/transport",
-		"github.com/ag-ui/go-sdk/pkg/state",
-		"github.com/ag-ui/go-sdk/pkg/messages",
-		"github.com/ag-ui/go-sdk/pkg/tools",
+		"github.com/mattsp1290/ag-ui/go-sdk/pkg/core",
+		"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events",
+		"github.com/mattsp1290/ag-ui/go-sdk/pkg/transport",
+		"github.com/mattsp1290/ag-ui/go-sdk/pkg/state",
+		"github.com/mattsp1290/ag-ui/go-sdk/pkg/messages",
+		"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools",
 	}
 	
 	report.WriteString("Core Package Dependencies:\n")
@@ -200,7 +200,7 @@ func (g *DependencyGraph) PrintDependencyReport() string {
 	report.WriteString("---------------------------\n")
 	
 	// Transport -> Events
-	if deps := g.getDependencies("github.com/ag-ui/go-sdk/pkg/transport", "github.com/ag-ui/go-sdk/pkg/core/events"); len(deps) > 0 {
+	if deps := g.getDependencies("github.com/mattsp1290/ag-ui/go-sdk/pkg/transport", "github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"); len(deps) > 0 {
 		report.WriteString("\nTransport -> Events:\n")
 		for _, dep := range deps {
 			report.WriteString(fmt.Sprintf("  - %s\n", dep))
@@ -208,7 +208,7 @@ func (g *DependencyGraph) PrintDependencyReport() string {
 	}
 	
 	// State -> Events
-	if deps := g.getDependencies("github.com/ag-ui/go-sdk/pkg/state", "github.com/ag-ui/go-sdk/pkg/core/events"); len(deps) > 0 {
+	if deps := g.getDependencies("github.com/mattsp1290/ag-ui/go-sdk/pkg/state", "github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"); len(deps) > 0 {
 		report.WriteString("\nState -> Events:\n")
 		for _, dep := range deps {
 			report.WriteString(fmt.Sprintf("  - %s\n", dep))
@@ -216,7 +216,7 @@ func (g *DependencyGraph) PrintDependencyReport() string {
 	}
 	
 	// State -> Transport
-	if deps := g.getDependencies("github.com/ag-ui/go-sdk/pkg/state", "github.com/ag-ui/go-sdk/pkg/transport"); len(deps) > 0 {
+	if deps := g.getDependencies("github.com/mattsp1290/ag-ui/go-sdk/pkg/state", "github.com/mattsp1290/ag-ui/go-sdk/pkg/transport"); len(deps) > 0 {
 		report.WriteString("\nState -> Transport:\n")
 		for _, dep := range deps {
 			report.WriteString(fmt.Sprintf("  - %s\n", dep))
@@ -242,7 +242,7 @@ func getPackagePath(rootPath, filePath string) string {
 	// Extract package path from file path
 	rel, _ := filepath.Rel(rootPath, filePath)
 	dir := filepath.Dir(rel)
-	return "github.com/ag-ui/go-sdk/" + strings.ReplaceAll(dir, string(filepath.Separator), "/")
+	return "github.com/mattsp1290/ag-ui/go-sdk/" + strings.ReplaceAll(dir, string(filepath.Separator), "/")
 }
 
 func contains(slice []string, item string) bool {

--- a/go-sdk/pkg/encoding/MIGRATION_GUIDE.md
+++ b/go-sdk/pkg/encoding/MIGRATION_GUIDE.md
@@ -37,8 +37,8 @@ If you're simply importing the encoding packages, **no changes are required**:
 
 ```go
 import (
-    _ "github.com/ag-ui/go-sdk/pkg/encoding/json"
-    _ "github.com/ag-ui/go-sdk/pkg/encoding/protobuf"
+    _ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
+    _ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/protobuf"
 )
 ```
 
@@ -51,8 +51,8 @@ If your application needs to ensure codecs are properly registered:
 ```go
 import (
     "log"
-    "github.com/ag-ui/go-sdk/pkg/encoding/json"
-    "github.com/ag-ui/go-sdk/pkg/encoding/protobuf"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/protobuf"
 )
 
 func main() {
@@ -97,7 +97,7 @@ package mylib
 
 import (
     "sync"
-    "github.com/ag-ui/go-sdk/pkg/encoding/json"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
 )
 
 var initOnce sync.Once

--- a/go-sdk/pkg/encoding/buffer_pooling_benchmark_test.go
+++ b/go-sdk/pkg/encoding/buffer_pooling_benchmark_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/go-sdk/pkg/encoding/buffer_sizing.go
+++ b/go-sdk/pkg/encoding/buffer_sizing.go
@@ -1,7 +1,7 @@
 package encoding
 
 import (
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // Buffer size constants optimized for different event types

--- a/go-sdk/pkg/encoding/buffer_test.go
+++ b/go-sdk/pkg/encoding/buffer_test.go
@@ -3,7 +3,7 @@ package encoding
 import (
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // TestOptimalBufferSizing tests the optimal buffer sizing function

--- a/go-sdk/pkg/encoding/codec_pool.go
+++ b/go-sdk/pkg/encoding/codec_pool.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // CodecPool manages pools for encoder and decoder instances

--- a/go-sdk/pkg/encoding/compatibility_adapters.go
+++ b/go-sdk/pkg/encoding/compatibility_adapters.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // ==============================================================================

--- a/go-sdk/pkg/encoding/comprehensive_benchmark_test.go
+++ b/go-sdk/pkg/encoding/comprehensive_benchmark_test.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/encoding/json"
-	"github.com/ag-ui/go-sdk/pkg/encoding/negotiation"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/negotiation"
 )
 
 // BenchmarkEncodingThroughput benchmarks encoding throughput for different formats

--- a/go-sdk/pkg/encoding/comprehensive_concurrency_test.go
+++ b/go-sdk/pkg/encoding/comprehensive_concurrency_test.go
@@ -25,10 +25,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	_ "github.com/ag-ui/go-sdk/pkg/encoding/json" // Register JSON codec
-	"github.com/ag-ui/go-sdk/pkg/encoding/negotiation"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	_ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json" // Register JSON codec
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/negotiation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/encoding/comprehensive_error_test.go
+++ b/go-sdk/pkg/encoding/comprehensive_error_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	_ "github.com/ag-ui/go-sdk/pkg/encoding/json" // Register JSON codec
-	"github.com/ag-ui/go-sdk/pkg/encoding/negotiation"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	_ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json" // Register JSON codec
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/negotiation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/encoding/comprehensive_integration_test.go
+++ b/go-sdk/pkg/encoding/comprehensive_integration_test.go
@@ -10,14 +10,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/encoding/json"
-	_ "github.com/ag-ui/go-sdk/pkg/encoding/json" // Register JSON codec
-	"github.com/ag-ui/go-sdk/pkg/encoding/negotiation"
-	"github.com/ag-ui/go-sdk/pkg/encoding/protobuf"
-	_ "github.com/ag-ui/go-sdk/pkg/encoding/protobuf" // Register Protobuf codec
-	"github.com/ag-ui/go-sdk/pkg/encoding/validation"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
+	_ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json" // Register JSON codec
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/negotiation"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/protobuf"
+	_ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/protobuf" // Register Protobuf codec
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/encoding/comprehensive_regression_test.go
+++ b/go-sdk/pkg/encoding/comprehensive_regression_test.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	_ "github.com/ag-ui/go-sdk/pkg/encoding/json" // Register JSON codec
-	"github.com/ag-ui/go-sdk/pkg/encoding/negotiation"
-	_ "github.com/ag-ui/go-sdk/pkg/encoding/protobuf" // Register Protobuf codec
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	_ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json" // Register JSON codec
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/negotiation"
+	_ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/protobuf" // Register Protobuf codec
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/encoding/concrete_factory_test.go
+++ b/go-sdk/pkg/encoding/concrete_factory_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/go-sdk/pkg/encoding/doc.go
+++ b/go-sdk/pkg/encoding/doc.go
@@ -28,7 +28,7 @@
 //
 // # Basic Usage
 //
-//	import "github.com/ag-ui/go-sdk/pkg/encoding"
+//	import "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
 //
 //	// Using the global registry
 //	registry := encoding.GetGlobalRegistry()

--- a/go-sdk/pkg/encoding/ensure_registered_test.go
+++ b/go-sdk/pkg/encoding/ensure_registered_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	_ "github.com/ag-ui/go-sdk/pkg/encoding/json"      // Register JSON codec
-	_ "github.com/ag-ui/go-sdk/pkg/encoding/protobuf" // Register Protobuf codec
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	_ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"      // Register JSON codec
+	_ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/protobuf" // Register Protobuf codec
 )
 
 func TestEnsureRegistered(t *testing.T) {

--- a/go-sdk/pkg/encoding/example_registration_test.go
+++ b/go-sdk/pkg/encoding/example_registration_test.go
@@ -4,16 +4,16 @@ import (
 	"fmt"
 	"log"
 	
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/encoding/json"
-	"github.com/ag-ui/go-sdk/pkg/encoding/protobuf"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/protobuf"
 )
 
 // Example demonstrating the new registration API
 func Example_registration() {
 	// Method 1: Import with side effects (backward compatible)
 	// The init() functions will attempt registration automatically
-	// import _ "github.com/ag-ui/go-sdk/pkg/encoding/json"
+	// import _ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
 	
 	// Method 2: Explicit registration with error handling
 	if err := json.EnsureRegistered(); err != nil {

--- a/go-sdk/pkg/encoding/example_registry_test.go
+++ b/go-sdk/pkg/encoding/example_registry_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
 )
 
 func ExampleFormatRegistry() {

--- a/go-sdk/pkg/encoding/factories.go
+++ b/go-sdk/pkg/encoding/factories.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // DefaultCodecFactory implements the simplified CodecFactory interface

--- a/go-sdk/pkg/encoding/goroutine_lifecycle_test.go
+++ b/go-sdk/pkg/encoding/goroutine_lifecycle_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/encoding/json"
-	_ "github.com/ag-ui/go-sdk/pkg/encoding/json" // Register JSON codec
-	"github.com/ag-ui/go-sdk/pkg/encoding/protobuf"
-	_ "github.com/ag-ui/go-sdk/pkg/encoding/protobuf" // Register Protobuf codec
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
+	_ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json" // Register JSON codec
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/protobuf"
+	_ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/protobuf" // Register Protobuf codec
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/encoding/integration_example_test.go
+++ b/go-sdk/pkg/encoding/integration_example_test.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	_ "github.com/ag-ui/go-sdk/pkg/encoding/json"      // Register JSON codec
-	_ "github.com/ag-ui/go-sdk/pkg/encoding/protobuf" // Register Protobuf codec
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	_ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"      // Register JSON codec
+	_ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/protobuf" // Register Protobuf codec
 )
 
 func ExampleFormatRegistry_integration() {

--- a/go-sdk/pkg/encoding/interface.go
+++ b/go-sdk/pkg/encoding/interface.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // ==============================================================================

--- a/go-sdk/pkg/encoding/interface_adapters.go
+++ b/go-sdk/pkg/encoding/interface_adapters.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // ==============================================================================

--- a/go-sdk/pkg/encoding/json/README.md
+++ b/go-sdk/pkg/encoding/json/README.md
@@ -17,8 +17,8 @@ This package provides JSON encoding and decoding functionality for AG-UI events,
 
 ```go
 import (
-    "github.com/ag-ui/go-sdk/pkg/core/events"
-    "github.com/ag-ui/go-sdk/pkg/encoding/json"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
 )
 
 // Create a codec with default options

--- a/go-sdk/pkg/encoding/json/concurrent_test.go
+++ b/go-sdk/pkg/encoding/json/concurrent_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // TestConcurrentEncodingWithoutMutex verifies that concurrent encoding works without mutexes

--- a/go-sdk/pkg/encoding/json/example_test.go
+++ b/go-sdk/pkg/encoding/json/example_test.go
@@ -7,9 +7,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/encoding/json"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
 )
 
 func ExampleJSONCodec() {

--- a/go-sdk/pkg/encoding/json/init.go
+++ b/go-sdk/pkg/encoding/json/init.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"sync"
 	
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/errors"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/errors"
 )
 
 var (

--- a/go-sdk/pkg/encoding/json/integration_test.go
+++ b/go-sdk/pkg/encoding/json/integration_test.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding/json"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
 )
 
 func TestJSONIntegration(t *testing.T) {

--- a/go-sdk/pkg/encoding/json/json.go
+++ b/go-sdk/pkg/encoding/json/json.go
@@ -1,7 +1,7 @@
 package json
 
 import (
-	"github.com/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
 )
 
 // Default codec instances for convenience

--- a/go-sdk/pkg/encoding/json/json_codec.go
+++ b/go-sdk/pkg/encoding/json/json_codec.go
@@ -3,8 +3,8 @@ package json
 import (
 	"context"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
 )
 
 // JSONCodec implements the new Codec interface for JSON encoding/decoding

--- a/go-sdk/pkg/encoding/json/json_decoder.go
+++ b/go-sdk/pkg/encoding/json/json_decoder.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"sync/atomic"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
 )
 
 // Ensure JSONDecoder implements the focused interfaces

--- a/go-sdk/pkg/encoding/json/json_encoder.go
+++ b/go-sdk/pkg/encoding/json/json_encoder.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"sync/atomic"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
 )
 
 // Ensure JSONEncoder implements the focused interfaces

--- a/go-sdk/pkg/encoding/json/json_streaming.go
+++ b/go-sdk/pkg/encoding/json/json_streaming.go
@@ -7,8 +7,8 @@ import (
 	"io"
 	"sync"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
 )
 
 // StreamingJSONEncoder implements the StreamEncoder interface for NDJSON format

--- a/go-sdk/pkg/encoding/json/json_test.go
+++ b/go-sdk/pkg/encoding/json/json_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
 )
 
 func TestJSONEncoder_Encode(t *testing.T) {

--- a/go-sdk/pkg/encoding/memory_leak_test.go
+++ b/go-sdk/pkg/encoding/memory_leak_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/encoding/negotiation/benchmark_test.go
+++ b/go-sdk/pkg/encoding/negotiation/benchmark_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/encoding/negotiation"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/negotiation"
 )
 
 func BenchmarkContentNegotiation(b *testing.B) {

--- a/go-sdk/pkg/encoding/negotiation/example_test.go
+++ b/go-sdk/pkg/encoding/negotiation/example_test.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/encoding/negotiation"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/negotiation"
 )
 
 func ExampleContentNegotiator_basic() {

--- a/go-sdk/pkg/encoding/negotiation/integration_example_test.go
+++ b/go-sdk/pkg/encoding/negotiation/integration_example_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/encoding/negotiation"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/negotiation"
 )
 
 // Example of how to integrate content negotiation with an HTTP handler

--- a/go-sdk/pkg/encoding/negotiation/negotiator.go
+++ b/go-sdk/pkg/encoding/negotiation/negotiator.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ag-ui/go-sdk/pkg/errors"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/errors"
 )
 
 var (

--- a/go-sdk/pkg/encoding/negotiation/negotiator_test.go
+++ b/go-sdk/pkg/encoding/negotiation/negotiator_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/encoding/negotiation"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/negotiation"
 )
 
 func TestContentNegotiator(t *testing.T) {

--- a/go-sdk/pkg/encoding/negotiation/parser.go
+++ b/go-sdk/pkg/encoding/negotiation/parser.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ag-ui/go-sdk/pkg/errors"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/errors"
 )
 
 // AcceptType represents a single media type from an Accept header

--- a/go-sdk/pkg/encoding/pool_test.go
+++ b/go-sdk/pkg/encoding/pool_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 func TestBufferPool(t *testing.T) {

--- a/go-sdk/pkg/encoding/pooled_codecs.go
+++ b/go-sdk/pkg/encoding/pooled_codecs.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"runtime"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // PooledEncoder wraps an encoder with pooling capabilities

--- a/go-sdk/pkg/encoding/protobuf/benchmark_test.go
+++ b/go-sdk/pkg/encoding/protobuf/benchmark_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding/json"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
 )
 
 // Benchmark comparing protobuf vs JSON encoding

--- a/go-sdk/pkg/encoding/protobuf/example_test.go
+++ b/go-sdk/pkg/encoding/protobuf/example_test.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding/protobuf"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/protobuf"
 )
 
 func ExampleProtobufEncoder() {

--- a/go-sdk/pkg/encoding/protobuf/init.go
+++ b/go-sdk/pkg/encoding/protobuf/init.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"sync"
 	
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/errors"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/errors"
 )
 
 var (

--- a/go-sdk/pkg/encoding/protobuf/integration_test.go
+++ b/go-sdk/pkg/encoding/protobuf/integration_test.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
 )
 
 func TestProtobufIntegration_CompleteWorkflow(t *testing.T) {

--- a/go-sdk/pkg/encoding/protobuf/protobuf_codec.go
+++ b/go-sdk/pkg/encoding/protobuf/protobuf_codec.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
 )
 
 // ProtobufCodec implements the new Codec interface for Protocol Buffer encoding/decoding

--- a/go-sdk/pkg/encoding/protobuf/protobuf_decoder.go
+++ b/go-sdk/pkg/encoding/protobuf/protobuf_decoder.go
@@ -5,10 +5,10 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/errors"
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/errors"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 )

--- a/go-sdk/pkg/encoding/protobuf/protobuf_encoder.go
+++ b/go-sdk/pkg/encoding/protobuf/protobuf_encoder.go
@@ -5,9 +5,9 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/go-sdk/pkg/encoding/protobuf/protobuf_streaming.go
+++ b/go-sdk/pkg/encoding/protobuf/protobuf_streaming.go
@@ -7,10 +7,10 @@ import (
 	"io"
 	"sync"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/errors"
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/errors"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/go-sdk/pkg/encoding/protobuf/protobuf_test.go
+++ b/go-sdk/pkg/encoding/protobuf/protobuf_test.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
 )
 
 func TestProtobufEncoder_Encode(t *testing.T) {

--- a/go-sdk/pkg/encoding/registration_simple_test.go
+++ b/go-sdk/pkg/encoding/registration_simple_test.go
@@ -3,8 +3,8 @@ package encoding_test
 import (
 	"testing"
 	
-	"github.com/ag-ui/go-sdk/pkg/encoding/json"
-	"github.com/ag-ui/go-sdk/pkg/encoding/protobuf"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/protobuf"
 )
 
 // TestJSONRegistration tests the new registration functions for JSON

--- a/go-sdk/pkg/encoding/registration_test.go
+++ b/go-sdk/pkg/encoding/registration_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/encoding/json"
-	_ "github.com/ag-ui/go-sdk/pkg/encoding/json" // Register JSON codec
-	"github.com/ag-ui/go-sdk/pkg/encoding/protobuf"
-	_ "github.com/ag-ui/go-sdk/pkg/encoding/protobuf" // Register Protobuf codec
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
+	_ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json" // Register JSON codec
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/protobuf"
+	_ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/protobuf" // Register Protobuf codec
 )
 
 // TestExplicitRegistration demonstrates explicit registration

--- a/go-sdk/pkg/encoding/registry.go
+++ b/go-sdk/pkg/encoding/registry.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding/registry"
-	"github.com/ag-ui/go-sdk/pkg/errors"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/registry"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/errors"
 )
 
 // Legacy type aliases for backward compatibility
@@ -781,9 +781,9 @@ func (r *FormatRegistry) EnsureRegistered(mimeTypes ...string) error {
 			for _, mt := range notSupported {
 				switch mt {
 				case "application/json":
-					errorMsg.WriteString(`import _ "github.com/ag-ui/go-sdk/pkg/encoding/json" `)
+					errorMsg.WriteString(`import _ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json" `)
 				case "application/x-protobuf":
-					errorMsg.WriteString(`import _ "github.com/ag-ui/go-sdk/pkg/encoding/protobuf" `)
+					errorMsg.WriteString(`import _ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/protobuf" `)
 				}
 			}
 		}

--- a/go-sdk/pkg/encoding/registry/registry_test.go
+++ b/go-sdk/pkg/encoding/registry/registry_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/encoding/registry"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/registry"
 )
 
 func TestCoreRegistryBasicOperations(t *testing.T) {

--- a/go-sdk/pkg/encoding/registry_patterns_test.go
+++ b/go-sdk/pkg/encoding/registry_patterns_test.go
@@ -3,11 +3,11 @@ package encoding_test
 import (
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/encoding/json"
-	_ "github.com/ag-ui/go-sdk/pkg/encoding/json" // Register JSON codec
-	"github.com/ag-ui/go-sdk/pkg/encoding/protobuf"
-	_ "github.com/ag-ui/go-sdk/pkg/encoding/protobuf" // Register Protobuf codec
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
+	_ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json" // Register JSON codec
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/protobuf"
+	_ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/protobuf" // Register Protobuf codec
 )
 
 // TestRegistryInitializationPatterns demonstrates proper patterns for registry initialization

--- a/go-sdk/pkg/encoding/registry_test.go
+++ b/go-sdk/pkg/encoding/registry_test.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	_ "github.com/ag-ui/go-sdk/pkg/encoding/json" // Register JSON codec
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	_ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json" // Register JSON codec
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/encoding/security/leak_test.go
+++ b/go-sdk/pkg/encoding/security/leak_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 	
-	"github.com/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
 	"go.uber.org/goleak"
 )
 

--- a/go-sdk/pkg/encoding/security/resource_limits_test.go
+++ b/go-sdk/pkg/encoding/security/resource_limits_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/encoding/json"
-	"github.com/ag-ui/go-sdk/pkg/encoding/validation"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/validation"
 )
 
 // TestBufferPoolResourceLimits tests that buffer pools enforce resource limits

--- a/go-sdk/pkg/encoding/simple_context_test.go
+++ b/go-sdk/pkg/encoding/simple_context_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding/json"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/go-sdk/pkg/encoding/streaming/chunked_encoder.go
+++ b/go-sdk/pkg/encoding/streaming/chunked_encoder.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/errors"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/errors"
 )
 
 // ChunkConfig holds configuration for chunked encoding

--- a/go-sdk/pkg/encoding/streaming/example_test.go
+++ b/go-sdk/pkg/encoding/streaming/example_test.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/encoding/json"
-	"github.com/ag-ui/go-sdk/pkg/encoding/streaming"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/streaming"
 )
 
 // Example_basicStreaming demonstrates basic streaming usage

--- a/go-sdk/pkg/encoding/streaming/goroutine_leak_test.go
+++ b/go-sdk/pkg/encoding/streaming/goroutine_leak_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/encoding/streaming/metrics.go
+++ b/go-sdk/pkg/encoding/streaming/metrics.go
@@ -6,7 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // StreamMetrics collects metrics for streaming operations

--- a/go-sdk/pkg/encoding/streaming/partial_operations_test.go
+++ b/go-sdk/pkg/encoding/streaming/partial_operations_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	agencoding "github.com/ag-ui/go-sdk/pkg/encoding"
-	agjson "github.com/ag-ui/go-sdk/pkg/encoding/json"
-	"github.com/ag-ui/go-sdk/pkg/encoding/validation"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	agencoding "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	agjson "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/encoding/streaming/stream_manager.go
+++ b/go-sdk/pkg/encoding/streaming/stream_manager.go
@@ -7,9 +7,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/errors"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/errors"
 )
 
 // StreamState represents the current state of a stream

--- a/go-sdk/pkg/encoding/streaming/streaming_test.go
+++ b/go-sdk/pkg/encoding/streaming/streaming_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
 )
 
 // mockEvent implements the Event interface for testing

--- a/go-sdk/pkg/encoding/streaming/unified_streaming.go
+++ b/go-sdk/pkg/encoding/streaming/unified_streaming.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"sync"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/errors"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/errors"
 )
 
 // UnifiedStreamCodec provides a format-agnostic streaming wrapper

--- a/go-sdk/pkg/encoding/updated_pool_test.go
+++ b/go-sdk/pkg/encoding/updated_pool_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	_ "github.com/ag-ui/go-sdk/pkg/encoding/json" // Register JSON codec
-	_ "github.com/ag-ui/go-sdk/pkg/encoding/protobuf" // Register Protobuf codec
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	_ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json" // Register JSON codec
+	_ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/protobuf" // Register Protobuf codec
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/encoding/validation/README.md
+++ b/go-sdk/pkg/encoding/validation/README.md
@@ -44,9 +44,9 @@ import (
     "context"
     "fmt"
     
-    "github.com/ag-ui/go-sdk/pkg/core/events"
-    "github.com/ag-ui/go-sdk/pkg/encoding/json"
-    "github.com/ag-ui/go-sdk/pkg/encoding/validation"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/validation"
 )
 
 func main() {

--- a/go-sdk/pkg/encoding/validation/benchmark.go
+++ b/go-sdk/pkg/encoding/validation/benchmark.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
 )
 
 // BenchmarkSuite provides performance benchmarking for encoding/validation

--- a/go-sdk/pkg/encoding/validation/compatibility.go
+++ b/go-sdk/pkg/encoding/validation/compatibility.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/errors"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/errors"
 )
 
 // CrossSDKValidator validates compatibility with other SDK implementations

--- a/go-sdk/pkg/encoding/validation/context_cancellation_test.go
+++ b/go-sdk/pkg/encoding/validation/context_cancellation_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/encoding/json"
-	"github.com/ag-ui/go-sdk/pkg/encoding/streaming"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/streaming"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/encoding/validation/example_test.go
+++ b/go-sdk/pkg/encoding/validation/example_test.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding/json"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
 )
 
 // Example demonstrates how to use the validation framework

--- a/go-sdk/pkg/encoding/validation/integration_test.go
+++ b/go-sdk/pkg/encoding/validation/integration_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
-	"github.com/ag-ui/go-sdk/pkg/encoding/json"
-	_ "github.com/ag-ui/go-sdk/pkg/encoding/json" // Register JSON codec
-	// "github.com/ag-ui/go-sdk/pkg/encoding/protobuf" // Disabled until protobuf package is fixed
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json"
+	_ "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/json" // Register JSON codec
+	// "github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding/protobuf" // Disabled until protobuf package is fixed
 )
 
 // TestEncodingDecodingPipeline tests the entire encoding/decoding pipeline

--- a/go-sdk/pkg/encoding/validation/recursion_depth_test.go
+++ b/go-sdk/pkg/encoding/validation/recursion_depth_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	agerrors "github.com/ag-ui/go-sdk/pkg/errors"
+	agerrors "github.com/mattsp1290/ag-ui/go-sdk/pkg/errors"
 )
 
 // TestValidateNestingDepthLimit verifies that validateNestingDepth prevents stack overflow attacks

--- a/go-sdk/pkg/encoding/validation/security.go
+++ b/go-sdk/pkg/encoding/validation/security.go
@@ -12,8 +12,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	agerrors "github.com/ag-ui/go-sdk/pkg/errors"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	agerrors "github.com/mattsp1290/ag-ui/go-sdk/pkg/errors"
 )
 
 // Recursion depth limits to prevent stack overflow attacks

--- a/go-sdk/pkg/encoding/validation/test_vectors_test.go
+++ b/go-sdk/pkg/encoding/validation/test_vectors_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // TestVectorSet represents a collection of test vectors

--- a/go-sdk/pkg/encoding/validation/validator.go
+++ b/go-sdk/pkg/encoding/validation/validator.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/encoding"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/encoding"
 )
 
 // FormatValidator defines the interface for format-specific validation

--- a/go-sdk/pkg/errors/README.md
+++ b/go-sdk/pkg/errors/README.md
@@ -18,7 +18,7 @@ The `errors` package provides comprehensive error handling utilities for the ag-
 ## Quick Start
 
 ```go
-import "github.com/ag-ui/go-sdk/pkg/errors"
+import "github.com/mattsp1290/ag-ui/go-sdk/pkg/errors"
 
 // Create a validation error
 err := errors.NewValidationError("INVALID_EMAIL", "Email validation failed").

--- a/go-sdk/pkg/errors/examples_test.go
+++ b/go-sdk/pkg/errors/examples_test.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/errors"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/errors"
 )
 
 // Example_basicErrorTypes demonstrates the use of custom error types

--- a/go-sdk/pkg/integration/event_flow_test.go
+++ b/go-sdk/pkg/integration/event_flow_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/state"
-	"github.com/ag-ui/go-sdk/pkg/transport"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/state"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/transport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/integration/type_safety_test.go
+++ b/go-sdk/pkg/integration/type_safety_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/transport"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/transport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/integration_test.go
+++ b/go-sdk/pkg/integration_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/state"
-	"github.com/ag-ui/go-sdk/pkg/transport"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/state"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/transport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/memory/backpressure.go
+++ b/go-sdk/pkg/memory/backpressure.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 	
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // BackpressureStrategy defines how backpressure should be handled

--- a/go-sdk/pkg/memory/memory_test.go
+++ b/go-sdk/pkg/memory/memory_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
 )
 
 // mockEvent implements events.Event for testing

--- a/go-sdk/pkg/memory/ring_buffer.go
+++ b/go-sdk/pkg/memory/ring_buffer.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // RingBuffer is a thread-safe circular buffer with configurable overflow policies

--- a/go-sdk/pkg/messages/README.md
+++ b/go-sdk/pkg/messages/README.md
@@ -14,7 +14,7 @@ The messages package provides a comprehensive, vendor-neutral message type syste
 ## Installation
 
 ```go
-import "github.com/ag-ui/go-sdk/pkg/messages"
+import "github.com/mattsp1290/ag-ui/go-sdk/pkg/messages"
 ```
 
 ## Quick Start

--- a/go-sdk/pkg/messages/example_memory_test.go
+++ b/go-sdk/pkg/messages/example_memory_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ag-ui/go-sdk/pkg/messages"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/messages"
 )
 
 // Example demonstrating memory-aware message history

--- a/go-sdk/pkg/messages/integration.go
+++ b/go-sdk/pkg/messages/integration.go
@@ -3,7 +3,7 @@ package messages
 import (
 	"fmt"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // ToEventMessage converts a Message to the events.Message format

--- a/go-sdk/pkg/messages/integration_test.go
+++ b/go-sdk/pkg/messages/integration_test.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/messages"
-	"github.com/ag-ui/go-sdk/pkg/messages/providers"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/messages"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/messages/providers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/messages/providers/anthropic.go
+++ b/go-sdk/pkg/messages/providers/anthropic.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ag-ui/go-sdk/pkg/messages"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/messages"
 )
 
 // streamingStatePool provides a pool of reusable streaming states

--- a/go-sdk/pkg/messages/providers/anthropic_basic_test.go
+++ b/go-sdk/pkg/messages/providers/anthropic_basic_test.go
@@ -3,7 +3,7 @@ package providers
 import (
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/messages"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/messages"
 )
 
 // TestAnthropicSimpleConversion tests basic message conversion to Anthropic format

--- a/go-sdk/pkg/messages/providers/anthropic_test.go
+++ b/go-sdk/pkg/messages/providers/anthropic_test.go
@@ -3,7 +3,7 @@ package providers
 import (
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/messages"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/messages"
 )
 
 func TestAnthropicConverter(t *testing.T) {

--- a/go-sdk/pkg/messages/providers/anthropic_tools_test.go
+++ b/go-sdk/pkg/messages/providers/anthropic_tools_test.go
@@ -3,7 +3,7 @@ package providers
 import (
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/messages"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/messages"
 )
 
 // TestAnthropicToolCallConversion tests converting messages with tool calls

--- a/go-sdk/pkg/messages/providers/benchmark_test.go
+++ b/go-sdk/pkg/messages/providers/benchmark_test.go
@@ -6,7 +6,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/messages"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/messages"
 )
 
 const (

--- a/go-sdk/pkg/messages/providers/converter.go
+++ b/go-sdk/pkg/messages/providers/converter.go
@@ -3,7 +3,7 @@ package providers
 import (
 	"fmt"
 
-	"github.com/ag-ui/go-sdk/pkg/messages"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/messages"
 )
 
 // Converter defines the interface for converting messages to/from provider formats

--- a/go-sdk/pkg/messages/providers/openai.go
+++ b/go-sdk/pkg/messages/providers/openai.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/ag-ui/go-sdk/pkg/messages"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/messages"
 )
 
 // OpenAIMessage represents a message in OpenAI format

--- a/go-sdk/pkg/messages/providers/openai_test.go
+++ b/go-sdk/pkg/messages/providers/openai_test.go
@@ -3,7 +3,7 @@ package providers
 import (
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/messages"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/messages"
 )
 
 func TestOpenAIConverter(t *testing.T) {

--- a/go-sdk/pkg/middleware/doc.go
+++ b/go-sdk/pkg/middleware/doc.go
@@ -7,7 +7,7 @@
 //
 // Example usage:
 //
-//	import "github.com/ag-ui/go-sdk/pkg/middleware"
+//	import "github.com/mattsp1290/ag-ui/go-sdk/pkg/middleware"
 //
 //	// Create logging middleware
 //	logger := middleware.NewLogging()

--- a/go-sdk/pkg/proto/generated/events.pb.go
+++ b/go-sdk/pkg/proto/generated/events.pb.go
@@ -1725,7 +1725,7 @@ const file_events_proto_rawDesc = "" +
 	"\fRUN_FINISHED\x10\f\x12\r\n" +
 	"\tRUN_ERROR\x10\r\x12\x10\n" +
 	"\fSTEP_STARTED\x10\x0e\x12\x11\n" +
-	"\rSTEP_FINISHED\x10\x0fB-Z+github.com/ag-ui/go-sdk/pkg/proto/generatedb\x06proto3"
+	"\rSTEP_FINISHED\x10\x0fB-Z+github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generatedb\x06proto3"
 
 var (
 	file_events_proto_rawDescOnce sync.Once

--- a/go-sdk/pkg/proto/generated/patch.pb.go
+++ b/go-sdk/pkg/proto/generated/patch.pb.go
@@ -167,7 +167,7 @@ const file_patch_proto_rawDesc = "" +
 	"\aREPLACE\x10\x02\x12\b\n" +
 	"\x04MOVE\x10\x03\x12\b\n" +
 	"\x04COPY\x10\x04\x12\b\n" +
-	"\x04TEST\x10\x05B-Z+github.com/ag-ui/go-sdk/pkg/proto/generatedb\x06proto3"
+	"\x04TEST\x10\x05B-Z+github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generatedb\x06proto3"
 
 var (
 	file_patch_proto_rawDescOnce sync.Once

--- a/go-sdk/pkg/proto/generated/types.pb.go
+++ b/go-sdk/pkg/proto/generated/types.pb.go
@@ -241,7 +241,7 @@ const file_types_proto_rawDesc = "" +
 	"\n" +
 	"\b_contentB\a\n" +
 	"\x05_nameB\x0f\n" +
-	"\r_tool_call_idB-Z+github.com/ag-ui/go-sdk/pkg/proto/generatedb\x06proto3"
+	"\r_tool_call_idB-Z+github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generatedb\x06proto3"
 
 var (
 	file_types_proto_rawDescOnce sync.Once

--- a/go-sdk/pkg/server/doc.go
+++ b/go-sdk/pkg/server/doc.go
@@ -10,7 +10,7 @@
 //
 // Example usage:
 //
-//	import "github.com/ag-ui/go-sdk/pkg/server"
+//	import "github.com/mattsp1290/ag-ui/go-sdk/pkg/server"
 //
 //	// Create a new server
 //	s := server.New(server.Config{

--- a/go-sdk/pkg/server/server.go
+++ b/go-sdk/pkg/server/server.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ag-ui/go-sdk/pkg/core"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core"
 )
 
 // Server represents an AG-UI server that can host multiple agents.

--- a/go-sdk/pkg/state/alert_notifiers.go
+++ b/go-sdk/pkg/state/alert_notifiers.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/common"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/common"
 	"go.uber.org/zap"
 )
 

--- a/go-sdk/pkg/state/concurrency_test.go
+++ b/go-sdk/pkg/state/concurrency_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	testutils "github.com/ag-ui/go-sdk/pkg/testing"
+	testutils "github.com/mattsp1290/ag-ui/go-sdk/pkg/testing"
 )
 
 // TestConcurrentStateUpdates_RaceCondition tests for race conditions during concurrent state updates

--- a/go-sdk/pkg/state/delta_example_test.go
+++ b/go-sdk/pkg/state/delta_example_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/ag-ui/go-sdk/pkg/state"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/state"
 )
 
 func ExampleDeltaComputer_ComputeDelta() {

--- a/go-sdk/pkg/state/doc.go
+++ b/go-sdk/pkg/state/doc.go
@@ -7,7 +7,7 @@
 //
 // Example usage:
 //
-//	import "github.com/ag-ui/go-sdk/pkg/state"
+//	import "github.com/mattsp1290/ag-ui/go-sdk/pkg/state"
 //
 //	// Create a state manager
 //	sm := state.NewManager()

--- a/go-sdk/pkg/state/docs/api-reference.md
+++ b/go-sdk/pkg/state/docs/api-reference.md
@@ -870,7 +870,7 @@ import (
     "log"
     "time"
 
-    "github.com/ag-ui/go-sdk/pkg/state"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/state"
 )
 
 func main() {

--- a/go-sdk/pkg/state/docs/configuration.md
+++ b/go-sdk/pkg/state/docs/configuration.md
@@ -24,7 +24,7 @@ package main
 
 import (
     "log"
-    "github.com/ag-ui/go-sdk/pkg/state"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/state"
 )
 
 func main() {

--- a/go-sdk/pkg/state/event_handlers.go
+++ b/go-sdk/pkg/state/event_handlers.go
@@ -13,7 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // StateEventHandler handles state-related events from the AG-UI protocol

--- a/go-sdk/pkg/state/event_handlers_demo.go
+++ b/go-sdk/pkg/state/event_handlers_demo.go
@@ -9,8 +9,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/state"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/state"
 )
 
 func main() {

--- a/go-sdk/pkg/state/event_handlers_example_test.go
+++ b/go-sdk/pkg/state/event_handlers_example_test.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/state"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/state"
 )
 
 // Example demonstrates basic usage of state event handlers

--- a/go-sdk/pkg/state/event_handlers_test.go
+++ b/go-sdk/pkg/state/event_handlers_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/state/goroutine_leak_test.go
+++ b/go-sdk/pkg/state/goroutine_leak_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 	
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go-sdk/pkg/state/integration_test.go
+++ b/go-sdk/pkg/state/integration_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/state/manager.go
+++ b/go-sdk/pkg/state/manager.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 	"github.com/google/uuid"
 )
 

--- a/go-sdk/pkg/state/store_example_test.go
+++ b/go-sdk/pkg/state/store_example_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/ag-ui/go-sdk/pkg/state"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/state"
 )
 
 func ExampleStateStore() {

--- a/go-sdk/pkg/state/test_reliability_improvements.go
+++ b/go-sdk/pkg/state/test_reliability_improvements.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	testutils "github.com/ag-ui/go-sdk/pkg/testing"
+	testutils "github.com/mattsp1290/ag-ui/go-sdk/pkg/testing"
 )
 
 // ReliableStateManagerTester provides utilities for testing state managers reliably

--- a/go-sdk/pkg/state/validation_rollback_example_test.go
+++ b/go-sdk/pkg/state/validation_rollback_example_test.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/ag-ui/go-sdk/pkg/state"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/state"
 )
 
 // Example_stateValidation demonstrates how to use state validation.

--- a/go-sdk/pkg/tools/builtin_test.go
+++ b/go-sdk/pkg/tools/builtin_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/tools/errors_test.go
+++ b/go-sdk/pkg/tools/errors_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/tools/example_test.go
+++ b/go-sdk/pkg/tools/example_test.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 )
 
 // Type-safe test parameter structures

--- a/go-sdk/pkg/tools/executor_enhanced_test.go
+++ b/go-sdk/pkg/tools/executor_enhanced_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/tools/executor_test.go
+++ b/go-sdk/pkg/tools/executor_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/tools/integration_test.go
+++ b/go-sdk/pkg/tools/integration_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/tools/providers_test.go
+++ b/go-sdk/pkg/tools/providers_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/tools/registry_enhanced_test.go
+++ b/go-sdk/pkg/tools/registry_enhanced_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/tools/registry_test.go
+++ b/go-sdk/pkg/tools/registry_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/tools/schema_test.go
+++ b/go-sdk/pkg/tools/schema_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/go-sdk/pkg/tools/secure_http.go
+++ b/go-sdk/pkg/tools/secure_http.go
@@ -3,7 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
-	"github.com/ag-ui/go-sdk/pkg/common"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/common"
 	"golang.org/x/net/idna"
 	"net"
 	"net/url"

--- a/go-sdk/pkg/tools/tool_test.go
+++ b/go-sdk/pkg/tools/tool_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/tools"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/tools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go-sdk/pkg/transport/backpressure.go
+++ b/go-sdk/pkg/transport/backpressure.go
@@ -6,7 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 	
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // BackpressureStrategy defines how backpressure should be handled

--- a/go-sdk/pkg/transport/backpressure_test.go
+++ b/go-sdk/pkg/transport/backpressure_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
 )
 
 // BackpressureMockEvent implements TransportEvent for testing

--- a/go-sdk/pkg/transport/benchmark_test.go
+++ b/go-sdk/pkg/transport/benchmark_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 	
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // BenchmarkEvent implements TransportEvent for benchmarking

--- a/go-sdk/pkg/transport/business_validators.go
+++ b/go-sdk/pkg/transport/business_validators.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/common"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/common"
 )
 
 // RangeValidator validates that a value falls within a specified range

--- a/go-sdk/pkg/transport/cmd/migrate/main.go
+++ b/go-sdk/pkg/transport/cmd/migrate/main.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/transport"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/transport"
 )
 
 func main() {

--- a/go-sdk/pkg/transport/demo_test.go
+++ b/go-sdk/pkg/transport/demo_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // DemoEvent implements TransportEvent for testing

--- a/go-sdk/pkg/transport/doc.go
+++ b/go-sdk/pkg/transport/doc.go
@@ -53,8 +53,8 @@
 //	import (
 //		"context"
 //		"time"
-//		"github.com/ag-ui/go-sdk/pkg/transport"
-//		"github.com/ag-ui/go-sdk/pkg/core/events"
+//		"github.com/mattsp1290/ag-ui/go-sdk/pkg/transport"
+//		"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 //	)
 //
 //	// Create type-safe configuration

--- a/go-sdk/pkg/transport/edge_cases_error_test.go
+++ b/go-sdk/pkg/transport/edge_cases_error_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // TestEdgeCaseErrors tests various edge case error scenarios

--- a/go-sdk/pkg/transport/error_test.go
+++ b/go-sdk/pkg/transport/error_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // ErrorTransport is a transport implementation that simulates various error conditions

--- a/go-sdk/pkg/transport/factory.go
+++ b/go-sdk/pkg/transport/factory.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 	
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // TransportFactory creates transport instances based on configuration.

--- a/go-sdk/pkg/transport/http/go.mod
+++ b/go-sdk/pkg/transport/http/go.mod
@@ -1,4 +1,4 @@
-module github.com/ag-ui/go-sdk/pkg/transport/http
+module github.com/mattsp1290/ag-ui/go-sdk/pkg/transport/http
 
 go 1.19
 

--- a/go-sdk/pkg/transport/http/transport.go
+++ b/go-sdk/pkg/transport/http/transport.go
@@ -16,8 +16,8 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/ag-ui/go-sdk/pkg/transport"
-	"github.com/ag-ui/go-sdk/pkg/transport/common"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/transport"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/transport/common"
 )
 
 // EventValidator defines the interface for event validation

--- a/go-sdk/pkg/transport/interfaces_core.go
+++ b/go-sdk/pkg/transport/interfaces_core.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 	
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // TransportEvent represents a transport event with metadata.

--- a/go-sdk/pkg/transport/interfaces_io.go
+++ b/go-sdk/pkg/transport/interfaces_io.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 	
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // ReadWriter combines io.Reader and io.Writer for raw data transport.

--- a/go-sdk/pkg/transport/interfaces_manager.go
+++ b/go-sdk/pkg/transport/interfaces_manager.go
@@ -3,7 +3,7 @@ package transport
 import (
 	"context"
 	
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // TransportManager manages transport instances

--- a/go-sdk/pkg/transport/interfaces_middleware.go
+++ b/go-sdk/pkg/transport/interfaces_middleware.go
@@ -3,7 +3,7 @@ package transport
 import (
 	"context"
 	
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // Middleware represents transport middleware for intercepting and modifying events.

--- a/go-sdk/pkg/transport/interfaces_serialization.go
+++ b/go-sdk/pkg/transport/interfaces_serialization.go
@@ -1,7 +1,7 @@
 package transport
 
 import (
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // Serializer handles serialization and deserialization of events for transport.

--- a/go-sdk/pkg/transport/manager_full.go
+++ b/go-sdk/pkg/transport/manager_full.go
@@ -8,7 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 	
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // ManagerConfig represents simplified transport configuration

--- a/go-sdk/pkg/transport/manager_full_error_test.go
+++ b/go-sdk/pkg/transport/manager_full_error_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // TestManagerConnectionErrors tests connection error scenarios for the full Manager

--- a/go-sdk/pkg/transport/manager_simple.go
+++ b/go-sdk/pkg/transport/manager_simple.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 	
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // SimpleManager provides basic transport management without import cycles

--- a/go-sdk/pkg/transport/manager_simple_error_test.go
+++ b/go-sdk/pkg/transport/manager_simple_error_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // DeterministicErrorTransport is a wrapper around ErrorTransport that fails based on event ID

--- a/go-sdk/pkg/transport/memory_management_test.go
+++ b/go-sdk/pkg/transport/memory_management_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
 )
 
 // mockEvent implements events.Event for testing

--- a/go-sdk/pkg/transport/memory_transport.go
+++ b/go-sdk/pkg/transport/memory_transport.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // MemoryConfig is the configuration for memory transport

--- a/go-sdk/pkg/transport/migration_test_helpers.go
+++ b/go-sdk/pkg/transport/migration_test_helpers.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // MigrationTestSuite provides comprehensive testing utilities for transport migration

--- a/go-sdk/pkg/transport/nil_checks_test.go
+++ b/go-sdk/pkg/transport/nil_checks_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // TestNilChecksTransportRegistry tests nil checks in transport registry methods

--- a/go-sdk/pkg/transport/performance_benchmark_test.go
+++ b/go-sdk/pkg/transport/performance_benchmark_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/transport/sse"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/transport/sse"
 )
 
 // BenchmarkStringAllocations compares string allocation patterns

--- a/go-sdk/pkg/transport/race_advanced_test.go
+++ b/go-sdk/pkg/transport/race_advanced_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // TestConcurrentTransportMetricsUpdate tests concurrent updates to transport metrics

--- a/go-sdk/pkg/transport/race_test.go
+++ b/go-sdk/pkg/transport/race_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // RaceTestTransport is a transport implementation specifically designed for race condition testing

--- a/go-sdk/pkg/transport/ring_buffer.go
+++ b/go-sdk/pkg/transport/ring_buffer.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // RingBuffer is a thread-safe circular buffer with configurable overflow policies

--- a/go-sdk/pkg/transport/sse/README.md
+++ b/go-sdk/pkg/transport/sse/README.md
@@ -24,8 +24,8 @@ import (
     "context"
     "log"
     
-    "github.com/ag-ui/go-sdk/pkg/transport/sse"
-    "github.com/ag-ui/go-sdk/pkg/core/events"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/transport/sse"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 func main() {
@@ -200,6 +200,6 @@ The transport is optimized for high-throughput scenarios:
 
 ## Dependencies
 
-- `github.com/ag-ui/go-sdk/pkg/core/events` - Event types and validation
-- `github.com/ag-ui/go-sdk/pkg/messages` - Error types
+- `github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events` - Event types and validation
+- `github.com/mattsp1290/ag-ui/go-sdk/pkg/messages` - Error types
 - Standard library packages: `net/http`, `context`, `encoding/json`, etc.

--- a/go-sdk/pkg/transport/sse/STREAMING.md
+++ b/go-sdk/pkg/transport/sse/STREAMING.md
@@ -54,8 +54,8 @@ import (
     "log"
     "time"
     
-    "github.com/ag-ui/go-sdk/pkg/core/events"
-    "github.com/ag-ui/go-sdk/pkg/transport/sse"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/transport/sse"
 )
 
 func main() {

--- a/go-sdk/pkg/transport/sse/config.go
+++ b/go-sdk/pkg/transport/sse/config.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core"
 	"go.uber.org/zap/zapcore"
 )
 

--- a/go-sdk/pkg/transport/sse/connection.go
+++ b/go-sdk/pkg/transport/sse/connection.go
@@ -11,9 +11,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/messages"
-	"github.com/ag-ui/go-sdk/pkg/transport/common"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/messages"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/transport/common"
 )
 
 // ConnectionState represents the current state of a connection

--- a/go-sdk/pkg/transport/sse/connection_example.go
+++ b/go-sdk/pkg/transport/sse/connection_example.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/messages"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/messages"
 )
 
 // Example demonstrates how to use the connection management system

--- a/go-sdk/pkg/transport/sse/example_test.go
+++ b/go-sdk/pkg/transport/sse/example_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // Example_basicUsage demonstrates basic SSE transport usage

--- a/go-sdk/pkg/transport/sse/goroutine_cleanup_test.go
+++ b/go-sdk/pkg/transport/sse/goroutine_cleanup_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	sdktesting "github.com/ag-ui/go-sdk/pkg/testing"
+	sdktesting "github.com/mattsp1290/ag-ui/go-sdk/pkg/testing"
 )
 
 // TestSSEGoroutineCleanup verifies that all goroutines are properly cleaned up

--- a/go-sdk/pkg/transport/sse/integration_test.go
+++ b/go-sdk/pkg/transport/sse/integration_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 	"github.com/chromedp/chromedp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/go-sdk/pkg/transport/sse/security.go
+++ b/go-sdk/pkg/transport/sse/security.go
@@ -23,7 +23,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/time/rate"
 	
-	"github.com/ag-ui/go-sdk/pkg/common"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/common"
 )
 
 // ============================================================================

--- a/go-sdk/pkg/transport/sse/stream.go
+++ b/go-sdk/pkg/transport/sse/stream.go
@@ -14,9 +14,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/messages"
-	"github.com/ag-ui/go-sdk/pkg/transport/common"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/messages"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/transport/common"
 )
 
 // EventStream manages efficient event streaming for HTTP SSE transport

--- a/go-sdk/pkg/transport/sse/stream_cleanup_test.go
+++ b/go-sdk/pkg/transport/sse/stream_cleanup_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // TestEventStreamCleanupTimeout tests that EventStream.Close() doesn't hang indefinitely

--- a/go-sdk/pkg/transport/sse/stream_example.go
+++ b/go-sdk/pkg/transport/sse/stream_example.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // ExampleEventStreaming demonstrates how to use the EventStream for efficient SSE event streaming

--- a/go-sdk/pkg/transport/sse/stream_test.go
+++ b/go-sdk/pkg/transport/sse/stream_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 func TestEventStreamCreation(t *testing.T) {

--- a/go-sdk/pkg/transport/sse/transport.go
+++ b/go-sdk/pkg/transport/sse/transport.go
@@ -12,9 +12,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/messages"
-	"github.com/ag-ui/go-sdk/pkg/transport/common"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/messages"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/transport/common"
 )
 
 // Transport interface defines the methods for event transport

--- a/go-sdk/pkg/transport/sse/transport_optimized.go
+++ b/go-sdk/pkg/transport/sse/transport_optimized.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/messages"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/messages"
 )
 
 // Pre-allocated string constants to avoid allocations

--- a/go-sdk/pkg/transport/sse/transport_test.go
+++ b/go-sdk/pkg/transport/sse/transport_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/transport/common"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/transport/common"
 )
 
 // TestSSETransport_NewSSETransport tests the creation of SSE transport

--- a/go-sdk/pkg/transport/testing.go
+++ b/go-sdk/pkg/transport/testing.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // MockTransport is a highly configurable mock implementation of the Transport interface

--- a/go-sdk/pkg/transport/testing_demo_test.go
+++ b/go-sdk/pkg/transport/testing_demo_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // TestMockTransportBasicUsage demonstrates basic mock transport usage

--- a/go-sdk/pkg/transport/transport_crash_test.go
+++ b/go-sdk/pkg/transport/transport_crash_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // CrashingTransport simulates a transport that crashes during operation

--- a/go-sdk/pkg/transport/validation_middleware.go
+++ b/go-sdk/pkg/transport/validation_middleware.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 	
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // ValidationMiddleware implements middleware for transport validation

--- a/go-sdk/pkg/transport/websocket/JWT_AUTHENTICATION.md
+++ b/go-sdk/pkg/transport/websocket/JWT_AUTHENTICATION.md
@@ -18,7 +18,7 @@ The WebSocket transport now includes proper JWT (JSON Web Token) validation to s
 
 ```go
 import (
-    "github.com/ag-ui/go-sdk/pkg/transport/websocket"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/transport/websocket"
 )
 
 // Create JWT validator with HMAC

--- a/go-sdk/pkg/transport/websocket/README.md
+++ b/go-sdk/pkg/transport/websocket/README.md
@@ -27,8 +27,8 @@ import (
     "context"
     "log"
 
-    "github.com/ag-ui/go-sdk/pkg/transport/websocket"
-    "github.com/ag-ui/go-sdk/pkg/messages"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/transport/websocket"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/messages"
 )
 
 func main() {

--- a/go-sdk/pkg/transport/websocket/bench_test.go
+++ b/go-sdk/pkg/transport/websocket/bench_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
 )
 
 // BenchmarkPerformanceManager_OptimizeMessage benchmarks message optimization

--- a/go-sdk/pkg/transport/websocket/concurrent_write_test.go
+++ b/go-sdk/pkg/transport/websocket/concurrent_write_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
-	testutils "github.com/ag-ui/go-sdk/pkg/testing"
+	testutils "github.com/mattsp1290/ag-ui/go-sdk/pkg/testing"
 )
 
 // createSimpleEchoServer creates a simple echo server for testing

--- a/go-sdk/pkg/transport/websocket/connection.go
+++ b/go-sdk/pkg/transport/websocket/connection.go
@@ -16,7 +16,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/time/rate"
 
-	"github.com/ag-ui/go-sdk/pkg/core"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core"
 )
 
 

--- a/go-sdk/pkg/transport/websocket/event_processing_test.go
+++ b/go-sdk/pkg/transport/websocket/event_processing_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // TestEventProcessingPipeline tests the event processing pipeline

--- a/go-sdk/pkg/transport/websocket/goroutine_cleanup_test.go
+++ b/go-sdk/pkg/transport/websocket/goroutine_cleanup_test.go
@@ -9,7 +9,7 @@ import (
 
 	"go.uber.org/zap"
 
-	sdktesting "github.com/ag-ui/go-sdk/pkg/testing"
+	sdktesting "github.com/mattsp1290/ag-ui/go-sdk/pkg/testing"
 )
 
 // TestWebSocketGoroutineCleanup verifies that all goroutines are properly cleaned up

--- a/go-sdk/pkg/transport/websocket/handler_test.go
+++ b/go-sdk/pkg/transport/websocket/handler_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // TestEventHandlerReliableRemoval tests that event handlers can be reliably added and removed

--- a/go-sdk/pkg/transport/websocket/integration_performance_test.go
+++ b/go-sdk/pkg/transport/websocket/integration_performance_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
 )
 
 // TestTransportPerformanceIntegration tests integration between transport and performance manager

--- a/go-sdk/pkg/transport/websocket/integration_test.go
+++ b/go-sdk/pkg/transport/websocket/integration_test.go
@@ -20,7 +20,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // testTransportConfig returns a DefaultTransportConfig with rate limiting disabled for tests

--- a/go-sdk/pkg/transport/websocket/load_test.go
+++ b/go-sdk/pkg/transport/websocket/load_test.go
@@ -19,8 +19,8 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	testutils "github.com/ag-ui/go-sdk/pkg/testing"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	testutils "github.com/mattsp1290/ag-ui/go-sdk/pkg/testing"
 )
 
 

--- a/go-sdk/pkg/transport/websocket/message_loss_test.go
+++ b/go-sdk/pkg/transport/websocket/message_loss_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // TestMessageLossPrevention specifically tests the 1000 message scenario that was failing

--- a/go-sdk/pkg/transport/websocket/network_test.go
+++ b/go-sdk/pkg/transport/websocket/network_test.go
@@ -19,7 +19,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 

--- a/go-sdk/pkg/transport/websocket/performance.go
+++ b/go-sdk/pkg/transport/websocket/performance.go
@@ -15,7 +15,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/time/rate"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // PerformanceConfig contains configuration for performance optimizations

--- a/go-sdk/pkg/transport/websocket/performance_minimal_test.go
+++ b/go-sdk/pkg/transport/websocket/performance_minimal_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
 )
 
 // TestPerformanceConfig tests the performance configuration

--- a/go-sdk/pkg/transport/websocket/pool.go
+++ b/go-sdk/pkg/transport/websocket/pool.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/golang-lru/v2"
 	"go.uber.org/zap"
 
-	"github.com/ag-ui/go-sdk/pkg/core"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core"
 )
 
 // ConnectionPool manages a pool of WebSocket connections with load balancing

--- a/go-sdk/pkg/transport/websocket/race_condition_test.go
+++ b/go-sdk/pkg/transport/websocket/race_condition_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
 )
 
 // TestRaceConditionFixes verifies that race conditions in message counting are resolved

--- a/go-sdk/pkg/transport/websocket/test_helpers.go
+++ b/go-sdk/pkg/transport/websocket/test_helpers.go
@@ -15,7 +15,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
-	testutils "github.com/ag-ui/go-sdk/pkg/testing"
+	testutils "github.com/mattsp1290/ag-ui/go-sdk/pkg/testing"
 )
 
 // ReliableTestServer provides a WebSocket server designed for reliable testing

--- a/go-sdk/pkg/transport/websocket/test_mocks.go
+++ b/go-sdk/pkg/transport/websocket/test_mocks.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
 )
 
 // MockEvent implements events.Event for websocket testing

--- a/go-sdk/pkg/transport/websocket/transport.go
+++ b/go-sdk/pkg/transport/websocket/transport.go
@@ -12,10 +12,10 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
-	"github.com/ag-ui/go-sdk/pkg/transport"
-	"github.com/ag-ui/go-sdk/pkg/transport/common"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/transport"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/transport/common"
 )
 
 // Atomic counter for generating unique subscription IDs

--- a/go-sdk/pkg/transport/websocket/transport_improved.go
+++ b/go-sdk/pkg/transport/websocket/transport_improved.go
@@ -13,10 +13,10 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/ag-ui/go-sdk/pkg/core"
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
-	"github.com/ag-ui/go-sdk/pkg/transport"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/transport"
 )
 
 // Atomic counter for generating unique subscription IDs in improved transport

--- a/go-sdk/pkg/transport/websocket/transport_test.go
+++ b/go-sdk/pkg/transport/websocket/transport_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
-	"github.com/ag-ui/go-sdk/pkg/core/events"
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
-	"github.com/ag-ui/go-sdk/pkg/transport/common"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/core/events"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/transport/common"
 )
 
 

--- a/go-sdk/proto/README.md
+++ b/go-sdk/proto/README.md
@@ -112,7 +112,7 @@ go run scripts/verify-proto-compatibility.go
 package main
 
 import (
-    "github.com/ag-ui/go-sdk/pkg/proto/generated"
+    "github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
     "google.golang.org/protobuf/proto"
     "google.golang.org/protobuf/encoding/protojson"
 )

--- a/go-sdk/scripts/verify-proto-compatibility.go
+++ b/go-sdk/scripts/verify-proto-compatibility.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/ag-ui/go-sdk/pkg/proto/generated"
+	"github.com/mattsp1290/ag-ui/go-sdk/pkg/proto/generated"
 )
 
 func main() {


### PR DESCRIPTION
Updated module paths and import statements throughout the codebase to use the correct package references. This includes updates to go.mod files, import statements in source files, and documentation references.

🤖 Generated with [Claude Code](https://claude.ai/code)