### PR TITLE
Add Makefile and dev scripts for Go example server

### DIFF
--- a/go-sdk/examples/server/Makefile
+++ b/go-sdk/examples/server/Makefile
@@ -1,0 +1,43 @@
+.PHONY: help run build test lint fmt vet tidy check dev clean
+
+# Default target
+help: ## Show this help message
+	@echo "Available targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+run: ## Run the server
+	go run ./cmd/server
+
+build: ## Build the server binary
+	@mkdir -p bin
+	go build -o bin/server ./cmd/server
+
+test: ## Run tests with coverage
+	go test ./... -cover
+
+fmt: ## Format Go code
+	go fmt ./...
+
+vet: ## Run Go vet
+	go vet ./...
+
+lint: ## Run golangci-lint (if available)
+	@if command -v golangci-lint >/dev/null 2>&1; then \
+		golangci-lint run; \
+	else \
+		echo "golangci-lint not found. Install with:"; \
+		echo "  go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest"; \
+		echo "or visit: https://golangci-lint.run/usage/install/"; \
+	fi
+
+tidy: ## Clean up go.mod and go.sum
+	go mod tidy
+
+check: fmt vet test lint ## Run all checks (fmt, vet, test, lint)
+
+dev: ## Start development server with live reload
+	@./scripts/dev.sh
+
+clean: ## Clean build artifacts and test files
+	rm -rf bin/
+	rm -f *.out *.prof *.test coverage.html server

--- a/go-sdk/examples/server/scripts/dev.sh
+++ b/go-sdk/examples/server/scripts/dev.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Development server script with live reload support
+# Supports reflex, air, or falls back to basic go run
+
+set -e
+
+# Check if we're in the right directory
+if [ ! -f "go.mod" ]; then
+    echo "Error: go.mod not found. Run this script from the server directory."
+    exit 1
+fi
+
+# Function to check if a command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Function to create minimal air config if it doesn't exist
+create_air_config() {
+    if [ ! -f ".air.toml" ]; then
+        cat > .air.toml << 'EOF'
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/main"
+  cmd = "go build -o ./tmp/main ./cmd/server"
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_root = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true
+EOF
+        echo "Created .air.toml configuration file"
+    fi
+}
+
+echo "Starting development server..."
+
+if command_exists reflex; then
+    echo "Using reflex for live reload"
+    exec reflex -r '\.(go|mod|sum)$' -- sh -c 'go run ./cmd/server'
+elif command_exists air; then
+    echo "Using air for live reload"
+    create_air_config
+    exec air
+else
+    echo "Live reload tools not found. Running with basic go run."
+    echo "For live reload, install one of:"
+    echo "  go install github.com/cespare/reflex@latest"
+    echo "  go install github.com/cosmtrek/air@latest"
+    echo ""
+    exec go run ./cmd/server
+fi


### PR DESCRIPTION
- Create comprehensive Makefile with targets: run, build, test, lint, fmt, vet, tidy, check, dev, clean, help
- Add scripts/dev.sh with live reload support (reflex/air/fallback)
- Enable developer ergonomics for quick iteration and consistent commands
- All targets tested and working correctly

🤖 Generated with [Claude Code](https://claude.ai/code)